### PR TITLE
Release: 2.1.1 -> 2.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,5 +24,5 @@ jobs:
 
       - name: Create release
         run: |
-            .ci/release.py
+            ./release.py
           


### PR DESCRIPTION
:no_entry_sign: Merging this will not result in a new version (no `fix`, `feat` or breaking changes). I recommend **delaying** this PR until more changes accumulate.

# 2.1.1 -> 2.1.1

### Ci
* Another fix (1deb3bee16754f5302f05552a8d644434cef03a1)
