### PR TITLE
Release: 2.1.1 -> 2.1.1

### DIFF
--- a/release.py
+++ b/release.py
@@ -22,6 +22,10 @@ def run(cmd):
 
 def get_repo():
     # origin = run(["git", "remote", "get-url", "origin"])
+    repo = os.environ.get("GITHUB_REPOSITORY", None)
+    if repo is not None:
+        return repo
+
     origin = git.remote("get-url", "origin")
     _, loc = origin.split(":", 1)
     repo, _ = loc.split(".", 1)


### PR DESCRIPTION
:no_entry_sign: Merging this will not result in a new version (no `fix`, `feat` or breaking changes). I recommend **delaying** this PR until more changes accumulate.

# 2.1.1 -> 2.1.1

### Ci
* Get repo from envvar (02b21bcd0c1e596e7543e4b216096be64685ecd2)
