### PR TITLE
Release: 2.1.1 -> 2.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,5 +24,7 @@ jobs:
 
       - name: Create release
         run: |
-            ./release.py
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          ./release.py
           


### PR DESCRIPTION
:no_entry_sign: Merging this will not result in a new version (no `fix`, `feat` or breaking changes). I recommend **delaying** this PR until more changes accumulate.

# 2.1.1 -> 2.1.1

### Ci
* Configure committer (bca6d2dd578e620bc9eab2becf5b043126cfbf3d)
