### PR TITLE
Release: 2.1.2 -> 2.1.2

### DIFF
--- a/release.py
+++ b/release.py
@@ -182,7 +182,13 @@ async def main():
       git.tag(next_tag)
 
       git.push("--follow-tags")
-      await asyncio.sleep(0.5) # make sure the tag is visible for github
+      for _ in range(5):
+          _all_tags = await gh.getitem("/repos/{repo}/tags")
+          all_tags = [t["name"] for t in _all_tags]
+          if next_tag in all_tags:
+              break
+          await asyncio.sleep(0.5) # make sure the tag is visible for github
+
       await gh.post(f"/repos/{repo}/releases", data={"body": md, "tag_name": next_tag})
 
 


### PR DESCRIPTION
:no_entry_sign: Merging this will not result in a new version (no `fix`, `feat` or breaking changes). I recommend **delaying** this PR until more changes accumulate.

# 2.1.2 -> 2.1.2

### Ci
* Another fix (c9d12bd85d92f372452c27a7a4d932a35cb50a1e)
